### PR TITLE
Fixed a bug that caused the program to respond to strings of numbers with more than 10 digits. / 10桁以上の数字列に反応してしまう不具合を修正 #6

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,9 +50,9 @@ client.on('message', message => {
   console.log("order_limits: " + D.dump(order_limits));
   console.log("order_attendees: " + D.dump(order_attendees));
 
-  const re = /(\d{10})/;
-  if ( re.test(message.content) ) {
-    const eventbrite_order_id = RegExp.lastMatch.toString();
+  const re = /#(\d{10})([^\d]|$)/;
+  if (( match_strings = re.exec(message.content)) !== null) {
+    const eventbrite_order_id = match_strings[1];
 
     if ( order_attendees[eventbrite_order_id] ) {
     


### PR DESCRIPTION
Fixed a bug that caused the program to respond to strings of numbers with more than 10 digits.

Responded to 10-digit numbers beginning with # (sharp) or ending with a non-numeric string after the 10-digit number.

#6 の10桁以上の数字列に反応してしまう不具合を修正

#(シャープ)始まりの10桁の数字で終わるか、10桁の数字の後ろに数字以外の文字列があるものに反応するようにした

